### PR TITLE
remove deprecated "base" import 

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { base } from "$app/paths";
+  // Your javascript code here
 </script>
 
 <h1>sveltekit-gh-pages</h1>
 <p>Deployed to GitHub Pages.</p>
-<a href="{base}/about">About</a>
+<a href="/about">About</a>


### PR DESCRIPTION
Remove the "base" import in the main +page.svelte script section because it's deprecated

Add the string "/about" to get into about route 